### PR TITLE
update manage/products_controller#start.

### DIFF
--- a/app/controllers/manage/products_controller.rb
+++ b/app/controllers/manage/products_controller.rb
@@ -3,6 +3,7 @@ class Manage::ProductsController < ApplicationController
   before_action :set_product,
                 only: [:show, :edit, :update, :destroy, :start, :accept]
   before_action :set_events, only: [:show]
+  before_action :require_stripe_account, only: [:start]
 
   # GET /admin/products/1
   # GET /seller/products/1
@@ -99,5 +100,12 @@ class Manage::ProductsController < ApplicationController
     params
       .require(:product)
       .permit(:title, :description, :price, :goal, :closes_on, :external_url)
+  end
+
+  def require_stripe_account
+    unless @product.user.stripe_account.present?
+      redirect_to [current_role, @product],
+                  alert: 'Stripe account does not exists.'
+    end
   end
 end

--- a/app/views/manage/products/show.html.slim
+++ b/app/views/manage/products/show.html.slim
@@ -48,13 +48,16 @@ ol.breadcrumb
       hr
       .row
         .col-md-offset-3.col-md-9
-          - if @product.pictures.present?
+          - if @product.user.stripe_account.nil?
+            .alert.alert-warning
+              p=t '.stripe_account_is_required_to_start'
+          - if @product.pictures.empty?
+            .alert.alert-warning
+              p=t '.picture_is_required_to_start'
+          - if @product.pictures.present? && @product.user.stripe_account.present?
             = link_to t('.start'), [:start, current_role, @product],
               method: :post,
               class: %w(btn btn-warning btn-lg)
-          - else
-            .alert.alert-warning
-              p=t '.picture_is_required_to_start'
     - if @product.goaled?
       - if (count = @product.bids.not_accepted.count) > 0
         hr

--- a/config/locales/views.ja.yml
+++ b/config/locales/views.ja.yml
@@ -59,6 +59,7 @@ ja:
         all_products: 全作品
       show:
         picture_is_required_to_start: 募集を開始するには写真を登録してください。
+        stripe_account_is_required_to_start: ストライプのアカウントが無い為、募集を開始することができません。
         instruction_is_required_to_accept: 入店させるには案内文を登録してください。
         start: 募集を開始する
         accept: 入店させる

--- a/spec/controllers/manage/products_controller_spec.rb
+++ b/spec/controllers/manage/products_controller_spec.rb
@@ -170,6 +170,17 @@ shared_examples_for Manage::ProductsController do
         }.not_to change { product.reload.started_at }
       end
     end
+
+    context 'with non-started product without stripe_account user' do
+      before do
+        product.user.stripe_account = nil
+      end
+      it 'fails to set started_at' do
+        expect {
+          post :start, { id: product.id }
+        }.not_to change { product.reload.started_at }
+      end
+    end
   end
 
   describe 'POST #accept' do
@@ -202,7 +213,11 @@ end
 RSpec.describe Admin::ProductsController, type: :controller do
   login_admin
   let(:role) { :admin }
-  let(:product) { FactoryGirl.create(:product) }
+  let(:product) {
+    FactoryGirl.create(
+      :product, user: FactoryGirl.create(:user, :with_stripe_account)
+    )
+  }
   it_behaves_like Manage::ProductsController
 end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -32,4 +32,8 @@ FactoryGirl.define do
   trait :without_user do
     user nil
   end
+
+  trait :with_stripe_account do
+    stripe_account
+  end
 end

--- a/spec/support/devise.rb
+++ b/spec/support/devise.rb
@@ -15,7 +15,7 @@ Module.new do
 
     def login_seller
       login_user do
-        FactoryGirl.create(:user, :seller)
+        FactoryGirl.create(:user, :seller, :with_stripe_account)
       end
     end
   end


### PR DESCRIPTION
@kayhide さん

https://github.com/runnable-inc/wonder_cat_factory/issues/28

作業中ですが、一旦PRだしました.

出品者が商品を公開状態にする際に、stripe accountがない場合はつくるようにするという変更をしました。これにより、"StripeAccount と紐付いてないと支払いでエラーになる。"ということをおきなくしました。

ただ、この変更だとrubocopにcontrollerの行数が長すぎると怒られてしまうのと、admin/stripe_account#createとコードが被ってしまうので微妙です。

なにか解決策を教えていただけませんでしょうか