### PR TITLE
Change mailgun SMTP to API request

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'carrierwave-aws'
 gem 'rmagick'
 gem 'redcarpet'
 gem 'stripe'
+gem 'mailgun_rails'
 
 gem 'bootstrap-sass'
 gem 'font-awesome-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,6 +195,10 @@ GEM
     lumberjack (1.0.10)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
+    mailgun_rails (0.8.0)
+      actionmailer (>= 3.2.13)
+      json (>= 1.7.7)
+      rest-client (>= 1.6.7)
     method_source (0.8.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
@@ -414,6 +418,7 @@ DEPENDENCIES
   kaminari
   letter_opener
   letter_opener_web
+  mailgun_rails
   momentjs-rails
   newrelic_rpm
   pg
@@ -448,4 +453,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.13.0
+   1.13.6

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,14 +1,9 @@
 Rails.application.configure do
   config.action_mailer.default_url_options = { host: ENV['HOST'] }
-  config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = {
-    address: ENV['MAILGUN_SMTP_SERVER'],
-    port: ENV['MAILGUN_SMTP_PORT'],
-    user_name: ENV['MAILGUN_SMTP_LOGIN'],
-    password: ENV['MAILGUN_SMTP_PASSWORD'],
-    domain: ENV['MAIL_HOST'],
-    authentication: :plain,
-    enable_starttls_auto: true
+  config.action_mailer.delivery_method = :mailgun
+  config.action_mailer.mailgun_settings = {
+    api_key: ENV['MAILGUN_API_KEY'],
+    domain: ENV['MAIL_HOST']
   }
 
   config.cache_classes = true


### PR DESCRIPTION
@kayhide さん

#29

SMTPからAPIへ変更のPRです。

公式のgemもあったのですが、
https://github.com/mailgun/mailgun-ruby

こちらの↓のがaction_mailerからつけたしでやれてかんたんだったので、こちらのgemを採用しました。
https://github.com/jorgemanrubia/mailgun_rails